### PR TITLE
Changes to putenv identifier and macro

### DIFF
--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -442,12 +442,16 @@ class FormatEpochTimeInMillisAsIso8601Test : public Test {
     // tzset() distinguishes between the TZ variable being present and empty
     // and not being present, so we have to consider the case of time_zone
     // being NULL.
-#if _MSC_VER || GTEST_OS_WINDOWS_MINGW
+#if _MSC_VER || GTEST_OS_WINDOWS_MINGW || __CODEGEARC__
     // ...Unless it's MSVC, whose standard library's _putenv doesn't
     // distinguish between an empty and a missing variable.
     const std::string env_var =
-        std::string("TZ=") + (time_zone ? time_zone : "");
-    _putenv(env_var.c_str());
+		std::string("TZ=") + (time_zone ? time_zone : "");
+#if __CODEGEARC__
+	putenv(env_var.c_str());
+#else
+	_putenv(env_var.c_str());
+#endif
     GTEST_DISABLE_MSC_WARNINGS_PUSH_(4996 /* deprecated function */)
     tzset();
     GTEST_DISABLE_MSC_WARNINGS_POP_()


### PR DESCRIPTION
Fixes #1 

In gtest_unittest.cc, add macro to remove underscore in front of identifier putenv so it is recognized by Rad Studio: http://docwiki.embarcadero.com/RADStudio/Berlin/en/Putenv,_wputenv

If not compiling on Rad Studio, we use _putenv as usual.