### PR TITLE
Fixes for Windows' localtime function and gtest-port.h

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -815,7 +815,7 @@ using ::std::tuple_size;
 // Typed tests need <typeinfo> and variadic macros, which GCC, VC++ 8.0,
 // Sun Pro CC, IBM Visual Age, and HP aCC support.
 #if defined(__GNUC__) || (_MSC_VER >= 1400) || defined(__SUNPRO_CC) || \
-    defined(__IBMCPP__) || defined(__HP_aCC)
+	defined(__IBMCPP__) || defined(__HP_aCC) || defined(__CODEGEARC__)
 # define GTEST_HAS_TYPED_TEST 1
 # define GTEST_HAS_TYPED_TEST_P 1
 #endif

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3555,7 +3555,7 @@ std::string FormatTimeInMillisAsSeconds(TimeInMillis ms) {
 static bool PortableLocaltime(time_t seconds, struct tm* out) {
 #if defined(_MSC_VER)
   return localtime_s(out, &seconds) == 0;
-#elif defined(__MINGW32__) || defined(__MINGW64__)
+#elif defined(__MINGW32__) || defined(__MINGW64__) ||defined(__CODEGEARC__)
   // MINGW <time.h> provides neither localtime_r nor localtime_s, but uses
   // Windows' localtime(), which has a thread-local tm buffer.
   struct tm* tm_ptr = localtime(&seconds);  // NOLINT


### PR DESCRIPTION
Fixes #1 Windows Compiling General

In gtest.cc, add Codegear to macro so that we can correctly use Windows' localtime() function in Rad Studio 10.2, since Windows does not have access to localtime_r()

In gtest-port.h, must add Codegear to macro or we get an error on line 5368 of gtest_unittest.cc: "gtest_unittest.cc: C++ Requires type specifier for all declarations." It thinks we're declaring a function with no return type, but we already declare it when we properly define GTEST_HAS_TYPED_TEST and GTEST_HAS_TYPED_TEST_P.